### PR TITLE
Fix removegridlines toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,6 +1,10 @@
-div.nogrid_gridline_minor {
+.jbrowse.removegrid .gridline {
 	border: none
 }
-div.nogrid_gridline_major {
+
+/* for pre 1.14 compatibility */
+.removegrid .gridline {
 	border: none
 }
+
+

--- a/js/main.js
+++ b/js/main.js
@@ -2,22 +2,12 @@
 define([
            'dojo/_base/declare',
            'dojo/_base/lang',
-           'dojo/dom-class',
-           'dojo/_base/array',
-           'dojo/query',
-           'dojo/_base/window',
-           'dojo/Deferred',
            'dijit/MenuItem',
            'JBrowse/Plugin'
        ],
        function(
            declare,
            lang,
-           domClass,
-           array,
-           query,
-           win,
-           Deferred,
            dijitMenuItem,
            JBrowsePlugin
        ) {
@@ -37,10 +27,7 @@ return declare( JBrowsePlugin,
     },
 
     toggleGridLines: function() {
-
-        query('.jbrowse').toggleClass('nogrid_gridline_minor');
-        query('.jbrowse').toggleClass('nogrid_gridline_major');
-        console.log(query('.jbrowse'));
+        dojo.toggleClass(this.browser.config.containerID, 'removegrid');
     }
 });
 });


### PR DESCRIPTION
This fixes the code by toggling the class at a higher level (the jbrowse div itself) and then that propagates/cascades down to the border: none on the particular gridline nodes.

Tested on JB 1.14.1 but should work on older versions too